### PR TITLE
Alternate drag trigger

### DIFF
--- a/DraggableCollectionView/Helpers/LSCollectionViewHelper.h
+++ b/DraggableCollectionView/Helpers/LSCollectionViewHelper.h
@@ -10,10 +10,14 @@
 
 - (id)initWithCollectionView:(UICollectionView *)collectionView;
 
+- (BOOL)beginDragAt:(NSIndexPath*)indexPath;
+- (void)endDrag;
+
 @property (nonatomic, readonly) UICollectionView *collectionView;
 @property (nonatomic, readonly) UIGestureRecognizer *longPressGestureRecognizer;
 @property (nonatomic, readonly) UIGestureRecognizer *panPressGestureRecognizer;
 @property (nonatomic, assign) UIEdgeInsets scrollingEdgeInsets;
 @property (nonatomic, assign) CGFloat scrollingSpeed;
 @property (nonatomic, assign) BOOL enabled;
+
 @end

--- a/DraggableCollectionView/UICollectionView+Draggable.h
+++ b/DraggableCollectionView/UICollectionView+Draggable.h
@@ -12,4 +12,8 @@
 @property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) UIEdgeInsets scrollingEdgeInsets;
 @property (nonatomic, assign) CGFloat scrollingSpeed;
+
+- (BOOL)beginDragAt:(NSIndexPath*)indexPath;
+- (void)endDrag;
+
 @end

--- a/DraggableCollectionView/UICollectionView+Draggable.m
+++ b/DraggableCollectionView/UICollectionView+Draggable.m
@@ -20,6 +20,16 @@
     return helper;
 }
 
+- (BOOL)beginDragAt:(NSIndexPath*)indexPath
+{
+    return [[self getHelper] beginDragAt:indexPath];
+}
+
+- (void)endDrag
+{
+    [[self getHelper] endDrag];
+}
+
 - (BOOL)draggable
 {
     return [self getHelper].enabled;

--- a/DraggableCollectionView/UICollectionViewDataSource_Draggable.h
+++ b/DraggableCollectionView/UICollectionViewDataSource_Draggable.h
@@ -17,5 +17,6 @@
 @optional
 
 - (BOOL)collectionView:(UICollectionView *)collectionView canMoveItemAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)toIndexPath;
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldTouchBeginDrag:(UITouch*)touch atIndexPath:(NSIndexPath *)indexPath;
 
 @end


### PR DESCRIPTION
Hi Luke,

So I needed a way to trigger re-ordering without relying solely on long tap. I loved your approach and built off of that. This basically adds another optional method to the delegate to allow the datasource to begin a move. For example tap on a certain part of a cell could trigger the move (a handle piece for example).
