### PR TITLE
Minor changes in the library.

### DIFF
--- a/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
+++ b/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
@@ -209,6 +209,29 @@ typedef NS_ENUM(NSInteger, _ScrollingDirection) {
     return indexPath;
 }
 
+- (NSIndexPath *)indexPathForItemAtPoint:(CGPoint)point
+{
+    NSArray *layoutAttrsInRect;
+    NSIndexPath *indexPath;
+    NSIndexPath *toIndexPath = self.layoutHelper.toIndexPath;
+    
+    // We need original positions of cells
+    self.layoutHelper.toIndexPath = nil;
+    layoutAttrsInRect = [self.collectionView.collectionViewLayout layoutAttributesForElementsInRect:self.collectionView.bounds];
+    self.layoutHelper.toIndexPath = toIndexPath;
+    
+    // What cell are we closest to?
+    for (UICollectionViewLayoutAttributes *layoutAttr in layoutAttrsInRect)
+    {
+        if (CGRectContainsPoint(layoutAttr.frame, point))
+        {
+            indexPath = layoutAttr.indexPath;
+        }
+    }
+    
+    return indexPath;
+}
+
 - (void)handleLongPressGesture:(UILongPressGestureRecognizer *)sender
 {
     if (sender.state == UIGestureRecognizerStateChanged) {
@@ -218,7 +241,7 @@ typedef NS_ENUM(NSInteger, _ScrollingDirection) {
         return;
     }
     
-    NSIndexPath *indexPath = [self indexPathForItemClosestToPoint:[sender locationInView:self.collectionView]];
+    NSIndexPath *indexPath = [self indexPathForItemAtPoint:[sender locationInView:self.collectionView]];
     
     switch (sender.state) {
         case UIGestureRecognizerStateBegan: {

--- a/DraggableCollectionView/UICollectionViewDataSource_Draggable.h
+++ b/DraggableCollectionView/UICollectionViewDataSource_Draggable.h
@@ -18,4 +18,9 @@
 
 - (BOOL)collectionView:(UICollectionView *)collectionView canMoveItemAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)toIndexPath;
 
+// When dragging by default a cell copy (image) is created and tranform is applied.
+// If you think the image looks blur when transform is applied, you can provide your own view by invoking this method.
+// This method assumes that your view big enough so no transform is applied. 
+- (UIView *)collectionView:(UICollectionView *)collectionView viewForDraggingAtIndexPath:(NSIndexPath *)indexPath;
+
 @end

--- a/FlowLayoutDemo/ViewController.m
+++ b/FlowLayoutDemo/ViewController.m
@@ -76,4 +76,17 @@
     [data2 insertObject:index atIndex:toIndexPath.item];
 }
 
+- (UIView *)collectionView:(UICollectionView *)collectionView viewForDraggingAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSMutableArray *data = [sections objectAtIndex:indexPath.section];
+    NSString *text = [data objectAtIndex:indexPath.item];
+    
+    UILabel *draggingView = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 200.0f, 200.0f)];
+    draggingView.backgroundColor = [UIColor lightGrayColor];
+    draggingView.font = [draggingView.font fontWithSize:draggingView.font.pointSize + 16.0f];
+    draggingView.textAlignment = NSTextAlignmentCenter;
+    draggingView.text = text;
+    return draggingView;
+}
+
 @end


### PR DESCRIPTION
Issue : When the dragging is initiated on the empty area the closest cell is matched.
Resolution : Need to find the exact cell.

Issue: Let us consider the collection view is just the bottom half of the window. Lets say user wants to drag the last cell to the first , say 100 cell to 1. User initiates the dragging and moves the cell to the top of the collection view. As the collection view is just the bottom part of the window the mock cell gets clipped.
Resolution : Add mock cell to the window.

Issue: Applying transform for the mock cell blurs the view.
Resolution: Provided the optional delegate method so user can provide his/her own view and also changing properties when needed like font colour or background colour.
