### PR TITLE
Fixes for dynamic sizes

### DIFF
--- a/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
+++ b/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
@@ -182,14 +182,14 @@ typedef NS_ENUM(NSInteger, _ScrollingDirection) {
             continue;
         }
         NSInteger items = [self.collectionView numberOfItemsInSection:i];
-        NSIndexPath *nextIndexPath = [NSIndexPath indexPathForItem:items inSection:i];
+        NSIndexPath *nextIndexPath = [NSIndexPath indexPathForItem:items - 1 inSection:i];
         UICollectionViewLayoutAttributes *layoutAttr;
         CGFloat xd, yd;
         
         if (items > 0) {
             layoutAttr = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:nextIndexPath];
-            xd = layoutAttr.center.x - point.x;
-            yd = layoutAttr.center.y - point.y;
+            xd = layoutAttr.size.width + layoutAttr.center.x - point.x;
+            yd = layoutAttr.size.height + layoutAttr.center.y - point.y;
         } else {
             // Trying to use layoutAttributesForItemAtIndexPath while section is empty causes EXC_ARITHMETIC (division by zero items)
             // So we're going to ask for the header instead. It doesn't have to exist.

--- a/DraggableCollectionView/Helpers/LSCollectionViewLayoutHelper.m
+++ b/DraggableCollectionView/Helpers/LSCollectionViewLayoutHelper.m
@@ -58,7 +58,27 @@
             layoutAttributes.indexPath = [NSIndexPath indexPathForItem:[collectionView numberOfItemsInSection:toIndexPath.section]
                                                              inSection:toIndexPath.section];
             if (layoutAttributes.indexPath.item != 0) {
-                layoutAttributes.center = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:layoutAttributes.indexPath].center;
+                CGPoint previousCenter = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:[collectionView numberOfItemsInSection:toIndexPath.section] - 2 inSection:toIndexPath.section]].center;
+                CGPoint currentCenter = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:[collectionView numberOfItemsInSection:toIndexPath.section] - 1 inSection:toIndexPath.section]].center;
+                
+                
+                
+                layoutAttributes.center = CGPointMake(currentCenter.x + currentCenter.x - previousCenter.x, currentCenter.y);
+                
+                
+                // If its going outside collection view on left, then move it
+                if (layoutAttributes.center.x < 0) {
+                    // standart spacing:
+                    CGPoint centerMinus3 = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:[collectionView numberOfItemsInSection:toIndexPath.section] - 3 inSection:toIndexPath.section]].center;
+                    CGPoint centerMinus2 = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:[collectionView numberOfItemsInSection:toIndexPath.section] - 2 inSection:toIndexPath.section]].center;
+                    
+                    CGFloat widthMinus2 = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:[collectionView numberOfItemsInSection:toIndexPath.section] - 2 inSection:toIndexPath.section]].size.width;
+                    
+                    CGFloat spacing = centerMinus2.x - centerMinus3.x - widthMinus2;
+                    
+                    layoutAttributes.center = CGPointMake(layoutAttributes.center.x + collectionView.frame.size.width + spacing, layoutAttributes.center.y);
+                }
+                    
             }
         }
         NSIndexPath *indexPath = layoutAttributes.indexPath;

--- a/FlowLayoutDemo/ViewController.h
+++ b/FlowLayoutDemo/ViewController.h
@@ -7,7 +7,7 @@
 #import <UIKit/UIKit.h>
 #import "UICollectionView+Draggable.h"
 
-@interface ViewController : UIViewController <UICollectionViewDataSource_Draggable, UICollectionViewDelegate>
+@interface ViewController : UIViewController <UICollectionViewDataSource_Draggable, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
 
 @property (weak, nonatomic) IBOutlet UICollectionView *collectionView;
 @end

--- a/FlowLayoutDemo/ViewController.m
+++ b/FlowLayoutDemo/ViewController.m
@@ -76,4 +76,11 @@
     [data2 insertObject:index atIndex:toIndexPath.item];
 }
 
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+    [[sections objectAtIndex:indexPath.section] objectAtIndex:indexPath.row];
+    
+    return CGSizeMake(100, 100);
+//    return indexPath.row == 0 ?  CGSizeMake(200, 100) : CGSizeMake(100, 100);
+}
+
 @end


### PR DESCRIPTION
Fixes issue when collection view cells have dynamic sizes, but for example you want to allow moving only 5 cells that have same size (this is case in my project).

For static sizes outcome of animations is exactly the same.
