### PR TITLE
Use `indexPathForItemAtPoint:` for long press.

### DIFF
--- a/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
+++ b/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
@@ -218,8 +218,8 @@ typedef NS_ENUM(NSInteger, _ScrollingDirection) {
         return;
     }
     
-    NSIndexPath *indexPath = [self indexPathForItemClosestToPoint:[sender locationInView:self.collectionView]];
-    
+    NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:[sender locationInView:self.collectionView]];
+        
     switch (sender.state) {
         case UIGestureRecognizerStateBegan: {
             if (indexPath == nil) {


### PR DESCRIPTION
`handleLongPressGesture:` was using `indexPathForItemClosestToPoint:` method to
retrieve the index path of the pressed cell. This works well on layouts
that fill the entire collection view space but not on other layouts: in the
latter case, the closest cell will be selected whereas this is the one under the
finger we want to be selected.

It now uses `indexPathForItemAtPoint:` instead of
`indexPathForItemClosestToPoint:` to get the touched cell.

An by the way, your lib is awesome: I added dragging in a complex layout in a couple of hours.
